### PR TITLE
Added Gitea, GitBucket, Bitbucket, Bitbucket Cloud and GitLab webhooks

### DIFF
--- a/flux/utils.py
+++ b/flux/utils.py
@@ -315,3 +315,10 @@ def get_github_signature(secret, payload_data):
   with the ``X-Hub-Signature`` header. '''
 
   return hmac.new(secret.encode('utf8'), payload_data, hashlib.sha1).hexdigest()
+
+def get_bitbucket_signature(secret, payload_data):
+  ''' Generates the Bitbucket HMAC signature from the repository
+  *secret* and the *payload_data*. The Bitbucket signature is sent
+  with the ``X-Hub-Signature`` header. '''
+
+  return hmac.new(secret.encode('utf8'), payload_data, hashlib.sha256).hexdigest()


### PR DESCRIPTION
References #12.

Added Gitea, GitBucket, Bitbucket, Bitbucket Cloud and GitLab webhooks support.
This pull request does not contain update on README or Dashboard/Integration page.

### Gitea
Developed and tested with self-hosted version **1.4.0**

https://docs.gitea.io/en-us/webhooks/

### GitBucket
Developed and tested with self-hosted version **4.23.0**
Uses SHA-1 for signature.

https://github.com/gitbucket/gitbucket/wiki/API-WebHook
_(it says "The GitBucket api/webhook is designed for compatibility with GitHub's implementation.", but that is not fully true)_


### Bitbucket
Developed and tested with self-hosted version **5.10.0**
Uses SHA-256 for signature.

https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html#Eventpayload-Push

### Bitbucket Cloud
This one is only developed by documentation and sending custom REST requests.
Does not support (by documentation) secret nor signatures.

https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-Push


### GitLab
Developed and tested with self-hosted version **10.7.1**

https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#push-events
https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#tag-events