### PR TITLE
Changed filename pattern for build artifact and log downloads.

### DIFF
--- a/flux/views.py
+++ b/flux/views.py
@@ -432,7 +432,8 @@ def download(build_id, data):
   if not build.exists(data):
     return abort(404)
   mime = 'application/zip' if data == Build.Data_Artifact else 'text/plain'
-  return utils.stream_file(build.path(data), mime=mime)
+  download_name = "{}-{}.{}".format(build.repo.name.replace("/", "_"), build.num, "zip" if data == Build.Data_Artifact else 'log')
+  return utils.stream_file(build.path(data), name=download_name, mime=mime)
 
 
 @app.route('/delete')


### PR DESCRIPTION
I've experienced the issue, when I have downloaded two build logs from different projects. Because I was in hurry, I was confused, which is which.

For this reason, I've decided to use existing functionality for definition of filename to be downloaded. Selected pattern is `group_name-buildnumber.extension`. Since `/` is forbidden character, it is replaced by `_`. Extension is defined in the same way as mime type.

So result could be e.g. `NiklasRosenstein_flux-10.zip` or `NiklasRosenstein_flux-11.log`.