### PR TITLE
Implement the functionality for starting new build.

### DIFF
--- a/flux/build.py
+++ b/flux/build.py
@@ -222,8 +222,11 @@ def do_build_(build, build_path, logger, logfile, terminate_event):
     # update ref; user could enter just branch name, e.g 'master'
     get_ref_cmd = ['git', 'rev-parse', '--symbolic-full-name', build_start_point]
     res_ref, res_ref_stdout = utils.run(get_ref_cmd, logger, cwd=build_path, return_stdout=True)
-    if res_ref == 0 and res_ref_stdout != None and res_ref_stdout.strip() != 'HEAD':
+    if res_ref == 0 and res_ref_stdout != None and res_ref_stdout.strip() != 'HEAD' and res_ref_stdout.strip() != '':
       build.ref = res_ref_stdout.strip()
+    elif res_ref_stdout.strip() == '':
+      # keep going, used ref was probably commit sha
+      pass
     else:
       logger.error('[Flux]: failed to read current ref')
       return False

--- a/flux/static/flux/css/style.css
+++ b/flux/static/flux/css/style.css
@@ -444,10 +444,10 @@ main {
 }
 
 #input-dialog .input-text {
-	margin: 1em 0.5em;
+	margin: 1rem 0;
 }
 
-#confirm-overlay {
+#confirm-overlay, #input-overlay {
 	background-color: rgba(38, 50, 56, 0.3);
 	bottom: 0;
 	display: none;

--- a/flux/static/flux/js/script.js
+++ b/flux/static/flux/js/script.js
@@ -54,6 +54,14 @@ $(document).ready(function() {
 		toggleConfirmDialog();
 	});
 
+	$('#input-dialog .input-text').on('keyup', function(event) {
+		if (event !== undefined && event.keyCode === 13) {
+			$('#input-dialog .input-ok').click();
+		} else if (event !== undefined && event.keyCode === 27) {
+			$('#input-dialog .input-cancel').click();
+		}
+	});
+
 	function confirmationYes(caller) {
 		return function(event) {
 			event.preventDefault();

--- a/flux/templates/base.html
+++ b/flux/templates/base.html
@@ -34,14 +34,15 @@
       <span class="input-icon">
         <i class="fa fa-exclamation-triangle"></i>
       </span>
-      <div class="input-message">confirm message</div>
-      <input class="input-text"/>
+      <div class="input-message">input message</div>
+      <input type="text" class="input-text" />
       <div class="input-buttons">
         <button class="input-ok"><i class="fa fa-check"></i>Ok</button>
         <button class="input-cancel"><i class="fa fa-times"></i>Cancel</button>
       </div>
     </div>
     <div id="confirm-overlay"></div>
+    <div id="input-overlay"></div>
     <header>
       <nav>
         <div class="brand">

--- a/flux/templates/view_repo.html
+++ b/flux/templates/view_repo.html
@@ -13,12 +13,12 @@
         <i class="fa fa-cog"></i>Options
       </a>
       <div class="dropdown-menu">
+        <a href="#" id="action-new-build" data-repository="{{ repo.id }}"><i class="fa fa-plus"></i>New Build</a>
         <a href="{{ url_for('edit_repo', repo_id=repo.id) }}"><i class="fa fa-pencil"></i>Edit</a>
         <a href="{{ url_for('delete', repo_id=repo.id) }}"
             data-confirmation="Are you sure you want to delete this repository? This operation can not be undone.">
           <i class="fa fa-trash"></i>Delete Repository
         </a>
-        <a href="#" id="action-new-build" data-repository="{{ repo.id }}"><i class="fa fa-plus"></i>New Build</a>
       </div>
     </li>
     <noscript>

--- a/flux/utils.py
+++ b/flux/utils.py
@@ -247,7 +247,7 @@ def zipdir(dirname, filename):
   zipf.close()
 
 
-def run(command, logger, cwd=None, env=None, shell=False):
+def run(command, logger, cwd=None, env=None, shell=False, return_stdout=False):
   ''' Run a subprocess with the specified *command*. The command
   and output of the command is logged to *logger*. *command* will
   automatically be converted to a string or list of command arguments
@@ -276,6 +276,8 @@ def run(command, logger, cwd=None, env=None, shell=False):
     else:
       if logger:
         logger.info('\n' + stdout)
+  if return_stdout:
+    return popen.returncode, stdout
   return popen.returncode
 
 


### PR DESCRIPTION
Hello,
I'm not going to lie, I couldn't help myself and had to dig into #35. I was thinking all the time about somekind database structure upgrade for adding flag, but since I'm not much into Python, I've decided to make it by described and proposed way.

First step is obviously checking, that `commit_sha` is `"0" * 32` and `ref` is defined. Second step is checkout by defined `ref`. Third and fourth steps are getting current sha and real ref. The reason for 4th step is fact, that user can insert ref just "develop" and it could be annoying to have many build with "refs/heads/..." and then just "develop". And that's it.

I've also added Enter/Escape listening into input text, because it add more natural feeling and moved Start Build as first item of dropdown - it will be used more times than edit or delete.