### PR TITLE
Fixed start build method in envrinment using URL prefix path.

### DIFF
--- a/flux/static/flux/js/script.js
+++ b/flux/static/flux/js/script.js
@@ -40,7 +40,7 @@ $(document).ready(function() {
 			field.value = '';
 			if (input.length > 0) {
 				let repoId = caller.attr('data-repository')
-				let url = '/build?repo_id=' + repoId + '&ref=' + input;
+				let url = start_build_url + '?repo_id=' + repoId + '&ref=' + input;
 				window.location = url;
 			}
 		});

--- a/flux/templates/view_repo.html
+++ b/flux/templates/view_repo.html
@@ -1,6 +1,12 @@
 {% extends "base.html" %}
 {% from "macros.html" import build_icon, build_ref, fmtdate %}
 {% set page_title = repo.name %}
+{% block head %}
+  <script>
+    var start_build_url = "{{ url_for('build') }}";
+  </script>
+{% endblock head %}
+
 {% block toolbar %}
   <li>
     <a href="{{ url_for('repositories') }}">

--- a/flux/views.py
+++ b/flux/views.py
@@ -491,7 +491,6 @@ def build():
   if not request.user.can_manage:
     return abort(403)
 
-  # TODO: Determine the commit SHA.
   commit = '0' * 32
   repo = session.query(Repository).get(repo_id)
   build = Build(repo=repo, commit_sha=commit, num=repo.build_count, ref=ref_name,


### PR DESCRIPTION
When I used configuration to hide application on URL prefix path, start build did not respect defined path. Due that it now loads url for starting the build by method `url_for('build')` in head block of view_repo page.