### PR TITLE
Allow to override repository files by CI user controlled files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 dist/
 build/
 builds/
+overrides/
 venv/
 .venv/
 .env/

--- a/flux/models.py
+++ b/flux/models.py
@@ -127,6 +127,7 @@ class Build(Base):
   Status = [Status_Queued, Status_Building, Status_Error, Status_Success, Status_Stopped]
 
   Data_BuildDir = 'build_dir'
+  Data_OverrideDir = 'override_dir'
   Data_Artifact = 'artifact'
   Data_Log = 'log'
 
@@ -161,6 +162,8 @@ class Build(Base):
       return base + '.zip'
     elif data == self.Data_Log:
       return base + '.log'
+    elif data == self.Data_OverrideDir:
+      return os.path.join(config.override_dir, self.repo.name.replace('/', os.sep))
     else:
       raise ValueError('invalid value for "data": {!r}'.format(data))
 

--- a/flux_config.py
+++ b/flux_config.py
@@ -73,6 +73,18 @@ else:
 ## is created by flux is <owner>/<repo>/<build_num> .
 build_dir = os.path.join(root_dir, 'builds')
 
+## The directory which contain file overrides for repositories.
+## Anything in the corresponding repository folder
+## will overwrite repository contents after clone.
+## This is especially useful, if you want to make sure your
+## desired build script and nothing else gets executed
+## or to override e.g. an icon.
+## -> Example:
+## override_dir/<owner>/<repo>/ containing icon.png
+## -> gets copied to (after clone)
+## build_dir/<owner>/<repo>/<build_num>/icon.png
+override_dir = os.path.join(root_dir, 'overrides')
+
 ## Full path to the SSH identity file, or None to let SSH decide.
 ssh_identity_file = None
 


### PR DESCRIPTION
This feature allows to override repository files by CI controlled folder.

* This allows to make the build-script manageable outside repository, without checking it in
* Same goes for deployment stuff - I do e.g. want to append " - Nightly" to some description, or swap some icons out. This makes it easy possible
* Also when fux-build-script gets into repo, devs with push access have control over it. E.g. especially for open source projects I want to make sure the stuff gets executed like I want. Even without being a org/repo-member and without push access its now possible to run CI, because you can create the build script yourself now.

I tried to keep the amount of changes at the lowest level so it is easy to review. No extra stuff, packages or like that needed. This all too is optional, doesn't create extra directories and doesn't fail if a override dir or it's parent don't exist.

This kind of opens doors for #31 - by just reading/writing file from override dir ;) . This again should be not very hard to accomplish.