### PR TITLE
Added basic editor for overriden build script for GUI.

### DIFF
--- a/flux/static/flux/css/style.css
+++ b/flux/static/flux/css/style.css
@@ -777,6 +777,10 @@ a .block:hover {
 	color: #2196F3;
 }
 
+#repo_build_script {
+	min-height: 10rem;
+}
+
 /* footer */
 footer {
 	background-color: #ECEFF1;

--- a/flux/templates/edit_repo.html
+++ b/flux/templates/edit_repo.html
@@ -45,6 +45,14 @@
       </div>
       <textarea id="repo_ref_whitelist" name="repo_ref_whitelist">{{ repo.ref_whitelist }}</textarea>
     </div>
+    <div class="field">
+      <label for="repo_build_script">Build script</label>
+      <div class="infobox">
+        Build script, that overrides default build script attached in project repository.
+        This also allows to not require build script to be placed in project repository.
+      </div>
+      <textarea id="repo_build_script" name="repo_build_script">{{ flux.utils.read_override_build_script(repo) if repo else "" }}</textarea>
+    </div>
     <button class="btn-primary">{{ "Update" if repo else "Add Repository" }}</button>
   </form>
   <script>

--- a/flux/utils.py
+++ b/flux/utils.py
@@ -367,4 +367,27 @@ def ping_repo(repo_url):
   env = {'GIT_SSH_COMMAND': ' '.join(map(shlex.quote, ssh_cmd))}
   ls_remote = ['git', 'ls-remote', '--exit-code', repo_url]
   res = run(ls_remote, None, env=env)
-  return res;
+  return res
+
+def get_override_build_script_path(repo):
+  return os.path.join(config.override_dir, repo.name.replace('/', os.sep), config.build_scripts[0])
+
+def read_override_build_script(repo):
+  build_script_path = get_override_build_script_path(repo)
+  if (os.path.isfile(build_script_path)):
+    build_script_file = open(build_script_path, mode='r')
+    build_script = build_script_file.read()
+    build_script_file.close()
+    return build_script
+  return ''
+
+def write_override_build_script(repo, build_script):
+  build_script_path = get_override_build_script_path(repo)
+  if build_script.strip() == '':
+    if (os.path.isfile(build_script_path)):
+      os.remove(build_script_path)
+  else:
+    makedirs(os.path.dirname(build_script_path))
+    build_script_file = open(build_script_path, mode='w')
+    build_script_file.write(build_script.replace('\r', ''))
+    build_script_file.close()

--- a/flux/views.py
+++ b/flux/views.py
@@ -338,6 +338,7 @@ def edit_repo(repo_id):
     clone_url = request.form.get('repo_clone_url', '')
     repo_name = request.form.get('repo_name', '').strip()
     ref_whitelist = request.form.get('repo_ref_whitelist', '')
+    build_script = request.form.get('repo_build_script', '')
     if len(repo_name) < 3 or repo_name.count('/') != 1:
       errors.append('Invalid repository name. Format must be owner/repo')
     if not clone_url:
@@ -354,9 +355,14 @@ def edit_repo(repo_id):
         repo.clone_url = clone_url
         repo.secret = secret
         repo.ref_whitelist = ref_whitelist
+      try:
+        utils.write_override_build_script(repo, build_script)
+      except:
+        errors.append('Could not make change on build script')
       session.add(repo)
       session.commit()
-      return redirect(repo.url())
+      if not errors:
+        return redirect(repo.url())
 
   return render_template('edit_repo.html', user=request.user, repo=repo, errors=errors)
 


### PR DESCRIPTION
According #41 and #31 I've created simple editor (without syntax highlighter) for custom build script.
Functionality is really simple, if there any script is added, it creates folder and file for `.flux-build` in overrides. If there is no text, build script is removed.

Saving into file could be little bit buggy, it could require additional check.